### PR TITLE
fix: IAM permissions break fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ No requirements.
 | <a name="input_boolean_type_organization_policies"></a> [boolean\_type\_organization\_policies](#input\_boolean\_type\_organization\_policies) | List of boolean type org policies to apply. | `list(string)` | <pre>[<br/>  "compute.disableNonFIPSMachineTypes",<br/>  "compute.skipDefaultNetworkCreation",<br/>  "sql.restrictPublicIp",<br/>  "storage.publicAccessPrevention"<br/>]</pre> | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for buckets. | `string` | `"bkt"` | no |
 | <a name="input_create_log_export"></a> [create\_log\_export](#input\_create\_log\_export) | Whether or not to create log export | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment type - 'sandbox' for internal testing, 'prod' for production deployments | `string` | `"sandbox"` | no |
 | <a name="input_folder_prefix"></a> [folder\_prefix](#input\_folder\_prefix) | Prefix for folders. | `string` | `"fldr"` | no |
 | <a name="input_group_org_admins"></a> [group\_org\_admins](#input\_group\_org\_admins) | Google Group for GCP Organization Administrators. | `string` | n/a | yes |
 | <a name="input_keyring_prefix"></a> [keyring\_prefix](#input\_keyring\_prefix) | Prefix for key rings. | `string` | `"kr"` | no |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Coalfire has tested this module with Terraform version 1.5.0 and the Hashicorp G
 module "bootstrap" {
   source = "github.com/Coalfire-CF/terraform-google-security-core"
 
+  # Must be set to prod to ensure org IAM permissions function properly; distinguishes from GCP sandbox env
+  environment      = "prod" 
+
   org_id           = var.org_id
   aw_folder_id     = var.aw_folder_id
   billing_account  = var.billing_account

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "google_organization_iam_member" "org_admins" {
-  for_each = toset(var.org_admin_roles)
+  for_each = var.environment == "prod" ? toset(var.org_admin_roles) : []
 
   org_id = var.org_id
   role   = each.value

--- a/variables.tf
+++ b/variables.tf
@@ -196,3 +196,13 @@ variable "winbastion_administrator_secret" {
   type        = bool
   default     = false
 }
+
+variable "environment" {
+  description = "Environment type - 'sandbox' for internal testing, 'prod' for production deployments"
+  type        = string
+  validation {
+    condition     = contains(["sandbox", "prod"], var.environment)
+    error_message = "Environment type must be either 'sandbox' or 'prod'."
+  }
+  default = "sandbox"
+}


### PR DESCRIPTION
Problem: Engineers were facing an issue in the Coalfire GCP sandbox in which org permissions were being removed from all users anytime a terraform destroy was run. This was due to a bug in how we set up the IAM permissions: we didn't take into account situations (such as the CF GCP sandbox) where the same admin org group would be used and permissions would need to stay persistent.

Solution: a 'flag' has been added called environment and will be required anytime the security-core module is used on a client project. By default this flag is set to 'sandbox', so engineers deploying into the sandbox will not need to use the environment variable. When using this pak for a client environment, this flag should be set to 'prod'. 